### PR TITLE
Adding nested and fielddata mappings for aggregation purposes.

### DIFF
--- a/policy/search_sync.py
+++ b/policy/search_sync.py
@@ -46,7 +46,67 @@ def es_client():
             'transaction_ids': {
                 'type':     'text',
                 'fielddata': True
-            }
+            },
+            'users' : {
+                'type': 'nested',
+                'properties': {
+                    'display_name' {
+                        'type': 'text',
+                        'fielddata': True
+                    },
+
+                }
+            },
+            'instruments' : {
+                'type': 'nested',
+                'properties': {
+                    'long_name' {
+                        'type': 'text',
+                        'fielddata': True
+                    },
+
+                }
+            },
+            'proposals' : {
+                'type': 'nested',
+                'properties': {
+                    'display_name' {
+                        'type': 'text',
+                        'fielddata': True
+                    },
+
+                }
+            },
+            'institutions' : {
+                'type': 'nested',
+                'properties': {
+                    'display_name' {
+                        'type': 'text',
+                        'fielddata': True
+                    },
+
+                }
+            },
+            'science_themes' : {
+                'type': 'nested',
+                'properties': {
+                    'display_name' {
+                        'type': 'text',
+                        'fielddata': True
+                    },
+
+                }
+            },
+            'instrument_groups' : {
+                'type': 'nested',
+                'properties': {
+                    'display_name' {
+                        'type': 'text',
+                        'fielddata': True
+                    },
+
+                }
+            },
         }
     }
     # pylint: disable=unexpected-keyword-arg


### PR DESCRIPTION
### Description

This is intended to create the ability for aggregations on users, instruments, proposals, institutions, science themes and instrument groups for the transactions object.

### Issues Resolved

Previously, the application have not been able to create aggregations on the above fields which are required for displaying facets.

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
